### PR TITLE
Adding a development server to foward production server websocket for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
-		"start": "bun run server.js",
-		"dev": "bun run --watch server.js"
+		"start": "NODE_ENV=production bun run server.js",
+		"dev": "NODE_ENV=development bun run --watch server.js"
 	},
 	"dependencies": {
 		"hono": "^4.11.0",

--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@ const playerSchema = z.strictObject({
 		y: z.int(),
 	}),
 });
+
 const requestSchema = z.strictObject({
 	jobId: z.string(),
 	players: z.array(playerSchema),
@@ -24,8 +25,7 @@ const app = new Hono();
 const PORT = process.env.PORT || 3000;
 const ROBLOX_TOKEN = process.env.ROBLOX_OTHER_KEY;
 
-if (!ROBLOX_TOKEN) throw new Error(`Token environment variable is missing`);
-
+if (!ROBLOX_TOKEN && process.env.NODE_ENV === "production") throw new Error(`Token environment variable is missing`);
 app.use("*", serveStatic({ root: "./public" }));
 
 let webSockets: WSContext<any>[] = [];
@@ -34,46 +34,88 @@ app.get("/status", (context) => {
 	return context.text("200 OK");
 });
 
-app.get(
+if (process.env.NODE_ENV == "development"){
+	// Forward from production server
+	app.get(
 	"/ws",
-	upgradeWebSocket((context) => {
+	upgradeWebSocket((_ctx) => {
 		return {
-			onOpen: (_event, webSocket) => {
-				webSockets.push(webSocket);
-			},
-			onClose: (_event, webSocket) => {
-				const index = webSockets.indexOf(webSocket);
-				if (index > -1) {
-					webSockets.splice(index, 1);
-				}
-			},
+		onOpen: (_event, client) => {
+			console.log("Client connected");
+			webSockets.push(client);
+			const upstream = new WebSocket("wss://map.dovedale.wiki/ws");
+
+			upstream.onopen = () => {
+			console.log("Connected to production server");
+			};
+
+			upstream.onmessage = (event) => {
+			if (client.readyState === WebSocket.OPEN) {
+				client.send(event.data);
+			}
+			};
+
+			client.onmessage = (event) => {
+			if (upstream.readyState === WebSocket.OPEN) {
+				upstream.send(event.data);
+			}
+			};
+
+			client.onclose = () => {
+			upstream.close();
+			const idx = webSockets.indexOf(client);
+			if (idx > -1) webSockets.splice(idx, 1);
+			};
+		},
 		};
 	}),
-);
+	);
 
+}
+else if (process.env.NODE_ENV == "production"){
+	app.get(
+		"/ws",
+		upgradeWebSocket((context) => {
+			return {
+				onOpen: (_event, webSocket) => {
+					webSockets.push(webSocket);
+				},
+				onClose: (_event, webSocket) => {
+					const index = webSockets.indexOf(webSocket);
+					if (index > -1) {
+						webSockets.splice(index, 1);
+					}
+				},
+			};
+		}),
+	);
+}
+
+if (process.env.NODE_ENV === "production"){
 app.post("/positions", async (context) => {
-	const result = requestSchema.safeParse(await context.req.json());
+		const result = requestSchema.safeParse(await context.req.json());
 
-	if (!result.success) {
-		return context.json({ success: false, errors: result.error.issues }, 400);
-	}
+		if (!result.success) {
+			return context.json({ success: false, errors: result.error.issues }, 400);
+		}
 
-	const { token: bodyToken, ...dataToSend } = result.data;
-	// once all Dovedale servers migrate to version using headers, body token support will be removed
-	const authorizationHeader = context.req.header("Authorization");
-	if (
-		authorizationHeader !== `Bearer ${ROBLOX_TOKEN}` &&
-		bodyToken !== ROBLOX_TOKEN
-	) {
-		return context.text("Invalid token", 401);
-	}
+		const { token: bodyToken, ...dataToSend } = result.data;
+		// once all Dovedale servers migrate to version using headers, body token support will be removed
+		const authorizationHeader = context.req.header("Authorization");
+		if (
+			authorizationHeader !== `Bearer ${ROBLOX_TOKEN}` &&
+			bodyToken !== ROBLOX_TOKEN
+		) {
+			return context.text("Invalid token", 401);
+		}
 
-	webSockets.forEach((webSocket) => {
-		webSocket.send(JSON.stringify(dataToSend));
-	});
+		webSockets.forEach((webSocket) => {
+			webSocket.send(JSON.stringify(dataToSend));
+		});
 
-	return context.json({ success: true });
+		return context.json({ success: true });
 });
+}
 
 export default {
 	fetch: app.fetch,

--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,7 @@ if (process.env.NODE_ENV == "development"){
 	// Forward from production server
 	app.get(
 	"/ws",
-	upgradeWebSocket((_ctx) => {
+	upgradeWebSocket((context) => {
 		return {
 		onOpen: (_event, client) => {
 			console.log("Client connected");

--- a/server.ts
+++ b/server.ts
@@ -61,7 +61,7 @@ if (process.env.NODE_ENV == "development"){
 		onOpen: (_event, client) => {
 			console.log("Client connected");
 			webSockets.push(client);
-			const upstream = new WebSocket("wss://map.dovedale.wiki/ws");
+			const upstream = new WebSocket("wss://map.dovedale.wiki/api/ws");
 
 			upstream.onopen = () => {
 			console.log("Connected to production server");
@@ -88,7 +88,7 @@ if (process.env.NODE_ENV == "development"){
 		};
 	}),
 	);
-
+}
 app.get("/api/servers/:jobId/players", async (context) => {
 	const authorizationHeader = context.req.header("Authorization");
 	if (authorizationHeader !== `Bearer ${ROBLOX_TOKEN}`) {


### PR DESCRIPTION
Train tooltip aren't working tho I'm not sure why

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Development Server WebSocket Proxy for Testing

## Overview
Adds a development-mode proxy that forwards local WebSocket connections to the production WebSocket, allowing local testing against live production data without requiring local token/API key setup.

## Key Changes

- Environment-conditional credential enforcement
  - `ROBLOX_TOKEN` and `GET_PLAYERS_API_KEY` are required in production but optional/bypassed in development.

- WebSocket proxy behavior (development only)
  - `/api/ws` now, when `NODE_ENV === "development"`, creates an upstream WebSocket to the production endpoint (wss://map.dovedale.wiki/ws) and bridges messages bidirectionally between the local client and upstream.
  - Replaces the prior raw onOpen/onClose local tracking approach with a proxy-based wiring between client and upstream, includes lifecycle logging and explicit cleanup (removal from the shared `webSockets` array).

- Request schema change
  - `requestSchema` now includes an optional (deprecated) `token` field.

- Public export surface expanded
  - Default export changed from `{ fetch: app.fetch }` to `{ fetch: app.fetch, port: PORT, websocket }`, exposing `port` and `websocket` in addition to `fetch`.

- Minor structural/formatting edits
  - Small reformatting around the WebSocket route and environment gating.

## Review feedback / action items
- Resolve merge conflicts.
- Apply consistent code formatting (e.g., Prettier).
- Rename identifier `idx` → `index` to follow the style guide (as requested by reviewer).
- Additional review requested from @coderabbitai.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->