### PR TITLE
Train icons

### DIFF
--- a/public/images/train.svg
+++ b/public/images/train.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12mm"
+   height="4mm"
+   viewBox="0 0 12 5.5"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+
+
+
+   <path 
+      id = "mainBody"
+      style="fill:#d45500;stroke:none;" 
+      d = "M0.5 0.5 l10 0 l1 2 l-1 2 l-10 0 Z"/>
+   <path 
+      id = "hood"
+      style="opacity:0.20;fill:#000000;stroke:none;" 
+      d = "M8.5 0.5 l2 0 l1 2 l-1 2 l-2 0 l1,-2Z"/>
+   <path
+       id="window" 
+       style="fill:none;stroke:#000080;stroke-width:1;"
+       d="M8.5 0.5 l 1,2 l -1,2"/>
+   <path 
+      id = "outline"
+      style="fill:none;stroke:#000000;stroke-width:1;" 
+      d = "M0.5 0.5 l10 0 l1 2 l-1 2 l-10 0 Z"/>
+  </g>
+</svg>

--- a/public/index.js
+++ b/public/index.js
@@ -480,7 +480,7 @@ const createWebSocket = () => {
 
 	state.ws = new WebSocket(
 		(location.protocol == "http:" ? "ws://" : "wss://") +
-			`${window.location.host}/api/ws`,
+		`${window.location.host}/api/ws`,
 	);
 
 	state.ws.addEventListener("open", () => {
@@ -492,7 +492,7 @@ const createWebSocket = () => {
 
 	state.ws.addEventListener("message", (event) => {
 		try {
-						const data = JSON.parse(event.data);
+			const data = JSON.parse(event.data);
 			const jobId = data.jobId;
 			const playersArray = Array.isArray(data.players) ? data.players : [];
 
@@ -745,9 +745,9 @@ const drawScene = () => {
 
 	const dotScaleFactor = Math.max(0.3, 1 / Math.pow(state.currentScale, 0.4));
 
-let activePlayerIds = []; 
+	let activePlayerIds = [];
 	playersToShow.forEach((player) => {
-activePlayerIds.push(String(player.userId));
+		activePlayerIds.push(String(player.userId));
 
 		const worldX = player.position?.x ?? 0;
 		const worldY = player.position?.y ?? 0;
@@ -773,7 +773,7 @@ activePlayerIds.push(String(player.userId));
 			else {
 				markerAngle = state.previousPlayerPosition[player.userId].angle ?? 0;
 			}
-			
+
 			// DRAW TRAIN
 			//  check train.svg. can't access the DOM of a svg within a <img>, but want to be able to dynamically color.
 			//  draw the train by hand!
@@ -794,7 +794,7 @@ activePlayerIds.push(String(player.userId));
 			context.lineWidth = 1;
 			context.stroke(new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")); // OUTLINE
 			context.translate(trainMarkerDim.x / 2, trainMarkerDim.y / 2);
-			context.scale(1/trainScale, 1/trainScale);
+			context.scale(1 / trainScale, 1 / trainScale);
 			context.rotate(-markerAngle);
 			context.translate(-canvasPosition.x, -canvasPosition.y);
 
@@ -813,7 +813,7 @@ activePlayerIds.push(String(player.userId));
 	});
 
 	Object.keys(state.previousPlayerPosition).forEach((previousPlayerId) => {
-		if(!activePlayerIds.includes(previousPlayerId)) {
+		if (!activePlayerIds.includes(previousPlayerId)) {
 			console.log("DELETING " + previousPlayerId);
 			delete state.previousPlayerPosition[previousPlayerId];
 		}

--- a/public/index.js
+++ b/public/index.js
@@ -678,6 +678,13 @@ const updateServerList = (data = null) => {
 	}
 };
 
+const TRAIN_PATH = {
+	body: new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z"),
+	hood: new Path2D("M8.5 1 l2 0 l1 2 l-1 2 l-2 0 l1,-2Z"),
+	window: new Path2D("M8.5 1 l 1,2 l -1,2"),
+	outline: new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")
+};
+
 const drawScene = () => {
 	const transformedPoint1 = context.transformedPoint(0, 0);
 	const transformedPoint2 = context.transformedPoint(
@@ -784,15 +791,15 @@ const drawScene = () => {
 			context.scale(trainScale, trainScale);
 			context.translate(-trainMarkerDim.x / 2, -trainMarkerDim.y / 2);
 			context.fillStyle = getPlayerColor(name);
-			context.fill(new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")); // BODY
+			context.fill(TRAIN_PATH.body); // BODY
 			context.fillStyle = "#00000020";
-			context.fill(new Path2D("M8.5 1 l2 0 l1 2 l-1 2 l-2 0 l1,-2Z")); // HOOD
+			context.fill(TRAIN_PATH.hood); // HOOD
 			context.strokeStyle = "#000080";
 			context.lineWidth = 1;
-			context.stroke(new Path2D("M8.5 1 l 1,2 l -1,2")); // WINDOW
+			context.stroke(TRAIN_PATH.window); // WINDOW
 			context.strokeStyle = isHovered ? "white" : "black";;
 			context.lineWidth = 1;
-			context.stroke(new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")); // OUTLINE
+			context.stroke(TRAIN_PATH.outline); // OUTLINE
 			context.translate(trainMarkerDim.x / 2, trainMarkerDim.y / 2);
 			context.scale(1 / trainScale, 1 / trainScale);
 			context.rotate(-markerAngle);

--- a/public/index.js
+++ b/public/index.js
@@ -129,6 +129,7 @@ class AppState {
 		this.loadedImages = 0;
 		this.totalImages = MAP_CONFIG.rows * MAP_CONFIG.columns;
 		this.staleCheckInterval = null;
+		this.previousPlayerPosition = {};
 	}
 
 	getAllPlayers() {
@@ -755,6 +756,49 @@ const drawScene = () => {
 		const baseRadius = isHovered ? 2.5 : 2;
 		const radius = baseRadius * dotScaleFactor;
 
+		if (player.trainData) {
+			const lastPlayerPosition = state.previousPlayerPosition[player.userId]?.position ?? { x: 0, y: 0 };
+
+			const dist = (player.position.x - lastPlayerPosition.x) ** 2 + (player.position.y - lastPlayerPosition.y) ** 2;
+			let markerAngle = Math.atan2((player.position.y - lastPlayerPosition.y), (player.position.x - lastPlayerPosition.x));
+
+			// take care of "disco trains" require minimum distance to change angle
+			if (dist > 1) {
+				if (state.previousPlayerPosition[player.userId]) {
+					state.previousPlayerPosition[player.userId].angle = markerAngle;
+				}
+			}
+			else {
+				markerAngle = state.previousPlayerPosition[player.userId].angle ?? 0;
+			}
+			
+			// DRAW TRAIN
+			//  check train.svg. can't access the DOM of a svg within a <img>, but want to be able to dynamically color.
+			//  draw the train by hand!
+			const trainMarkerDim = { x: 12, y: 6 };
+			const trainScale = isHovered ? 0.5 : 0.4;
+			context.translate(canvasPosition.x, canvasPosition.y);
+			context.rotate(markerAngle);
+			context.scale(trainScale, trainScale);
+			context.translate(-trainMarkerDim.x / 2, -trainMarkerDim.y / 2);
+			context.fillStyle = getPlayerColor(name);
+			context.fill(new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")); // BODY
+			context.fillStyle = "#00000020";
+			context.fill(new Path2D("M8.5 1 l2 0 l1 2 l-1 2 l-2 0 l1,-2Z")); // HOOD
+			context.strokeStyle = "#000080";
+			context.lineWidth = 1;
+			context.stroke(new Path2D("M8.5 1 l 1,2 l -1,2")); // WINDOW
+			context.strokeStyle = isHovered ? "white" : "black";;
+			context.lineWidth = 1;
+			context.stroke(new Path2D("M1 1 l10 0 l1 2 l-1 2 l-10 0 Z")); // OUTLINE
+			context.translate(trainMarkerDim.x / 2, trainMarkerDim.y / 2);
+			context.scale(1/trainScale, 1/trainScale);
+			context.rotate(-markerAngle);
+			context.translate(-canvasPosition.x, -canvasPosition.y);
+
+			state.previousPlayerPosition[player.userId] = { position: player.position, angle: markerAngle };
+		}
+		else { // not a train
 		context.fillStyle = getPlayerColor(name);
 		context.beginPath();
 		context.arc(canvasPosition.x, canvasPosition.y, radius, 0, Math.PI * 2);
@@ -763,6 +807,7 @@ const drawScene = () => {
 		context.strokeStyle = isHovered ? "white" : "black";
 		context.lineWidth = Math.max((isHovered ? 0.7 : 0.4) * scaleFactor, 0.25);
 		context.stroke();
+		}
 	});
 
 	if (state.currentScale > 300) return;

--- a/public/index.js
+++ b/public/index.js
@@ -492,7 +492,7 @@ const createWebSocket = () => {
 
 	state.ws.addEventListener("message", (event) => {
 		try {
-			const data = JSON.parse(event.data);
+						const data = JSON.parse(event.data);
 			const jobId = data.jobId;
 			const playersArray = Array.isArray(data.players) ? data.players : [];
 
@@ -745,7 +745,10 @@ const drawScene = () => {
 
 	const dotScaleFactor = Math.max(0.3, 1 / Math.pow(state.currentScale, 0.4));
 
+let activePlayerIds = []; 
 	playersToShow.forEach((player) => {
+activePlayerIds.push(String(player.userId));
+
 		const worldX = player.position?.x ?? 0;
 		const worldY = player.position?.y ?? 0;
 		const name = player.username ?? "Unknown";
@@ -798,14 +801,21 @@ const drawScene = () => {
 			state.previousPlayerPosition[player.userId] = { position: player.position, angle: markerAngle };
 		}
 		else { // not a train
-		context.fillStyle = getPlayerColor(name);
-		context.beginPath();
-		context.arc(canvasPosition.x, canvasPosition.y, radius, 0, Math.PI * 2);
-		context.fill();
+			context.fillStyle = getPlayerColor(name);
+			context.beginPath();
+			context.arc(canvasPosition.x, canvasPosition.y, radius, 0, Math.PI * 2);
+			context.fill();
 
-		context.strokeStyle = isHovered ? "white" : "black";
-		context.lineWidth = Math.max((isHovered ? 0.7 : 0.4) * scaleFactor, 0.25);
-		context.stroke();
+			context.strokeStyle = isHovered ? "white" : "black";
+			context.lineWidth = Math.max((isHovered ? 0.7 : 0.4) * scaleFactor, 0.25);
+			context.stroke();
+		}
+	});
+
+	Object.keys(state.previousPlayerPosition).forEach((previousPlayerId) => {
+		if(!activePlayerIds.includes(previousPlayerId)) {
+			console.log("DELETING " + previousPlayerId);
+			delete state.previousPlayerPosition[previousPlayerId];
 		}
 	});
 

--- a/public/index.js
+++ b/public/index.js
@@ -814,7 +814,6 @@ const drawScene = () => {
 
 	Object.keys(state.previousPlayerPosition).forEach((previousPlayerId) => {
 		if (!activePlayerIds.includes(previousPlayerId)) {
-			console.log("DELETING " + previousPlayerId);
 			delete state.previousPlayerPosition[previousPlayerId];
 		}
 	});


### PR DESCRIPTION
![trainIcons2](https://github.com/user-attachments/assets/58ac69e5-dfa2-4ff8-9260-5322d34b8ab1)

Changes the icon for users in trains to... a train. 

Explained it in a comment, but since I wanted to be able to change the color of the train, I could not use context.drawImage(), as I need to modify the SVG DOM to make those changes, and the function only takes in <img> and there does not seem to be a mechanism to do this. So by hand it is! 

<img width="319" height="283" alt="image" src="https://github.com/user-attachments/assets/c2e15fee-1a79-4835-a8ff-b82eabc88a92" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Replaces the circular icon for train players with a custom-drawn, rotatable train marker on the map.

### Technical Implementation

**public/index.js**
- Added `state.previousPlayerPosition = {}` to track per-player previous position and angle.
- Minor formatting change to WebSocket URL string concatenation (no semantic change).
- In `drawScene()`:
  - Introduced `activePlayerIds` to track rendered players.
  - For players with `trainData`:
    - Compute a movement-based `markerAngle` from the delta between current position and the stored previous position.
    - Use a minimum movement threshold (squared distance) to avoid jitter; reuse the last stored angle when movement is below the threshold.
    - Draw the train marker manually on canvas (rotated/scaled transforms and Path2D shapes for body, hood, window, outline), supporting hover/state-based scaling and dynamic color.
    - Persist `{ position, angle }` to `state.previousPlayerPosition` for use in subsequent frames.
  - Non-train players still render as the original circular dot + stroke in an `else` branch.
  - After rendering, prune `state.previousPlayerPosition` entries for users not present in `activePlayerIds` to prevent stale data accumulation and address a potential memory leak flagged by reviewers.

### Rationale

Manual canvas drawing was required because `context.drawImage()` with SVG `<img>` elements does not permit modifying the SVG DOM to change colors; constructing the marker manually allows dynamic color, rotation, and hover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->