### PR TITLE
fix: actually cancel stale server timeouts before deleting them

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -113,6 +113,7 @@ async function positionsApi(context: Context) {
 
 	if (serverTimeouts.has(data.jobId)) {
 		console.log("Clearing current timeout");
+		clearTimeout(serverTimeouts.get(data.jobId)); // ensure we actually cancel the timeout before deleting it, otherwise it will still fire even if deleted from the map
 		serverTimeouts.delete(data.jobId);
 	}
 


### PR DESCRIPTION

`serverTimeouts.delete(data.jobId)` was removing the map reference but never calling clearTimeout, so the timer kept running and would eventually fire and incorrectly delete the `playersCache` entry for that server

I found that with just 6 servers each posting once per second, this was accumulating up to 180 timers, any of which could fire and make an active server look like it had gone offline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for stale server timeout handling

The `positionsApi` handler in `server.ts` now explicitly calls `clearTimeout()` on an existing timeout before removing it from the `serverTimeouts` Map. Previously, the Map entry was deleted without cancelling the underlying timer, allowing it to continue firing and incorrectly purge active server data from the cache. The fix ensures stale timeouts are properly terminated before their references are discarded, preventing ghost timers from accumulating (observed at ~180 stale timers with six servers posting once per second).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dovedalerailway/dovedale-map/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->