### PR TITLE
fix: handle dead websocket connections during broadcast

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -134,8 +134,14 @@ async function positionsApi(context: Context) {
 		);
 	}
 
-	webSockets.forEach((webSocket) => {
-		webSocket.send(JSON.stringify(data));
+	const message = JSON.stringify(data);
+	webSockets = webSockets.filter((webSocket) => {
+		try {
+			webSocket.send(message);
+			return true;
+		} catch { // returning false will remove the dead socket from the webSockets array
+			return false;
+		}
 	});
 
 	return context.json({ success: true });


### PR DESCRIPTION

if a client's connection died without cleanly closing, sending to it would
throw and cut off every other client that hadn't received the update yet

I also gave JSON.stringify its own variable outside the loop since the message is identical for every client, so it only runs once per broadcast instead of once per connected client