### PR TITLE
chore: clean up dead websocket connections and cache stringify'd data

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -134,8 +134,13 @@ async function positionsApi(context: Context) {
 		);
 	}
 
-	webSockets.forEach((webSocket) => {
-		webSocket.send(JSON.stringify(data));
+	const message = JSON.stringify(data);
+	webSockets = webSockets.filter((webSocket) => {
+		if (webSocket.readyState !== 1) {
+			return false;
+		}
+		webSocket.send(message);
+		return true;
 	});
 
 	return context.json({ success: true });


### PR DESCRIPTION

dead websockets were accumulating in the array indefinitely

if a client dropped without cleanly closing, it could stay in the array and we would keep attempting to send to it on every broadcast forever

so we check `readyState` before sending, and if a socket isn't open we both skip it AND remove it from the array at the same time

I also gave JSON.stringify its own variable outside the loop since the message is identical for every client anyways, that way it only runs once per broadcast instead of once per connected client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves WebSocket connection management and performance in the `positionsApi` endpoint on `server.ts`.

## Changes

The broadcast logic when sending position updates to connected WebSocket clients has been refactored:

1. **Connection cleanup**: The `webSockets` array is now filtered to remove dead connections. Sockets with `readyState !== 1` (not open) are identified and removed from the active list, preventing accumulation of stale connections when clients disconnect without clean closure.

2. **Performance optimization**: The JSON payload is now stringified once before the send loop (`const message = JSON.stringify(data)`) rather than being stringified for each connected client, reducing redundant serialization work.

The filtering is accomplished by using `webSockets.filter()` to iterate through connections: it sends the message only to open sockets and removes non-open ones in a single pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dovedalerailway/dovedale-map/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->