### PR TITLE
fix: respond to game server before broadcasting to WebSockets

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -165,17 +165,23 @@ async function positionsApi(context: Context) {
 	}
 
 	const message = JSON.stringify(data);
-	const response = context.json({ success: true });
 
-	webSockets = webSockets.filter((webSocket) => {
-		if (webSocket.readyState !== 1) {
-			return false;
-		}
-		webSocket.send(message);
-		return true;
+	Promise.resolve().then(() => {
+		webSockets = webSockets.filter((webSocket) => {
+			if (webSocket.readyState !== 1) {
+				return false;
+			}
+			try {
+				webSocket.send(message);
+			} catch (err) {
+				console.error("WebSocket send error:", err);
+				return false;
+			}
+			return true;
+		});
 	});
 
-	return response;
+	return context.json({ success: true });
 }
 
 app.post("/api/positions", positionsApi);

--- a/server.ts
+++ b/server.ts
@@ -165,6 +165,8 @@ async function positionsApi(context: Context) {
 	}
 
 	const message = JSON.stringify(data);
+	const response = context.json({ success: true });
+
 	webSockets = webSockets.filter((webSocket) => {
 		if (webSocket.readyState !== 1) {
 			return false;
@@ -173,7 +175,7 @@ async function positionsApi(context: Context) {
 		return true;
 	});
 
-	return context.json({ success: true });
+	return response;
 }
 
 app.post("/api/positions", positionsApi);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

**server.ts**: Modified the `positionsApi` handler to create and return the response before broadcasting to WebSocket clients. The response object is now instantiated before the WebSocket broadcast loop, and then returned after the broadcast completes, rather than being created and returned at the end. This ensures the game server receives its response without waiting for WebSocket operations to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->